### PR TITLE
Create Codespaces with custom devcontainer

### DIFF
--- a/plugins/github-codespaces/README.md
+++ b/plugins/github-codespaces/README.md
@@ -60,6 +60,9 @@ Website: [https://github.com/codespaces](https://github.com/codespaces)
      description: backstage.io
      annotations:
        github.com/project-slug: 'backstage/backstage'
+       # Add below annotation for a custom devcontainer configuration with
+       # relative path of devcontainer.json file from root of the repository
+       github.com/devcontainer-path: .devcontainer/devcontainer.json 
    spec:
      type: website
      lifecycle: production

--- a/plugins/github-codespaces/src/api/GithubCodespacesApi.tsx
+++ b/plugins/github-codespaces/src/api/GithubCodespacesApi.tsx
@@ -78,9 +78,10 @@ export type GithubCodespacesApi = {
      * @param displayName - Display Name for the codespace
      * @param owner - Organisation or user name for the repository
      * @param repositoryName - Name of the repository
+     * @param devcontainerPath - Path to use for Codespace devcontainer
      * @returns details of the codespace to start
      */
-    createCodespaceInEntityForUser: (displayName: string, owner: string, repositoryName: string) =>
+    createCodespaceInEntityForUser: (displayName: string, owner: string, repositoryName: string, devcontainerPath?: string) =>
         Promise<
             RestEndpointMethodTypes['codespaces']['createWithRepoForAuthenticatedUser']['response']['data']
         > 

--- a/plugins/github-codespaces/src/api/GithubCodespacesApiClient.tsx
+++ b/plugins/github-codespaces/src/api/GithubCodespacesApiClient.tsx
@@ -94,7 +94,7 @@ export class GithubCodespacesApiClient implements GithubCodespacesApi {
         return response.data
     }
 
-    async createCodespaceInEntityForUser(displayName: string, owner: string, repositoryName: string): Promise<
+    async createCodespaceInEntityForUser(displayName: string, owner: string, repositoryName: string, devcontainerPath?: string): Promise<
         RestEndpointMethodTypes['codespaces']['createWithRepoForAuthenticatedUser']['response']['data']
     > {
         const octokit = await this.getOctokit('github.com')
@@ -102,6 +102,7 @@ export class GithubCodespacesApiClient implements GithubCodespacesApi {
             display_name: displayName,
             owner: owner,
             repo: repositoryName,
+            devcontainer_path: devcontainerPath,
         })
 
         return response.data

--- a/plugins/github-codespaces/src/hooks/useOpenCodespaceInEntityForUser.ts
+++ b/plugins/github-codespaces/src/hooks/useOpenCodespaceInEntityForUser.ts
@@ -17,7 +17,7 @@
 import { Entity } from "@backstage/catalog-model";
 import { githubCodespacesApiRef } from "../api"; 
 import { useApi } from "@backstage/core-plugin-api";
-import { getProjectNameFromEntity } from "../utils";
+import { getDevcontainerPathFromEntity, getProjectNameFromEntity } from "../utils";
 import { useCallback } from "react";
 
 /**
@@ -44,6 +44,7 @@ export function useOpenCodespaceInEntityForUser(
         // Get the repository owner and name from the project-slug
         // and filter the codespaces for the Authenticated User
         const projectName = getProjectNameFromEntity(entity);
+        const devcontainerPath = getDevcontainerPathFromEntity(entity);
         const [owner, repositoryName] = (projectName ?? '/').split('/');
         const codespacesListInRepo = await api.listCodespacesInRepoForUser(owner, repositoryName); 
 
@@ -65,7 +66,7 @@ export function useOpenCodespaceInEntityForUser(
         // else start the top most existing codespace 
         return (
             (count === 0) ?
-            ((await api.createCodespaceInEntityForUser(entityName,owner,repositoryName))) :
+            ((await api.createCodespaceInEntityForUser(entityName,owner,repositoryName,devcontainerPath))) :
             api.startCodespaceForUser(verifiedCodespaces[0].name)
         );
     },[api, entity])

--- a/plugins/github-codespaces/src/utils/getDevcontainerPathFromEntity.ts
+++ b/plugins/github-codespaces/src/utils/getDevcontainerPathFromEntity.ts
@@ -17,15 +17,15 @@
 import { Entity } from "@backstage/catalog-model";
 
 /**
- * Annotation required for the Github Codespaces
+ * (Optional) Annotation for the Github Codespaces devcontainer path
  *  @public
  */
 export const GITHUB_CODESPACES_DEVCONTAINER_ANNOTATION = 'github.com/devcontainer-path';
 
 /**
- * Get the project name from the entity annotations
+ * Get the devcontainer path from the entity annotations
  * @param entity - Entity object
- * @returns the value of the project slug in the entity defintion annotations
+ * @returns the value of the devcontainer path in the entity defintion annotations
  */
 export const getDevcontainerPathFromEntity = (entity: Entity) => 
     entity?.metadata.annotations?.[GITHUB_CODESPACES_DEVCONTAINER_ANNOTATION] ?? '';

--- a/plugins/github-codespaces/src/utils/getDevcontainerPathFromEntity.ts
+++ b/plugins/github-codespaces/src/utils/getDevcontainerPathFromEntity.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 The Kubin Kloud Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from "@backstage/catalog-model";
+
+/**
+ * Annotation required for the Github Codespaces
+ *  @public
+ */
+export const GITHUB_CODESPACES_DEVCONTAINER_ANNOTATION = 'github.com/devcontainer-path';
+
+/**
+ * Get the project name from the entity annotations
+ * @param entity - Entity object
+ * @returns the value of the project slug in the entity defintion annotations
+ */
+export const getDevcontainerPathFromEntity = (entity: Entity) => 
+    entity?.metadata.annotations?.[GITHUB_CODESPACES_DEVCONTAINER_ANNOTATION] ?? '';

--- a/plugins/github-codespaces/src/utils/index.ts
+++ b/plugins/github-codespaces/src/utils/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from './getProjectNameFromEntity';
+export * from './getDevcontainerPathFromEntity';
 export * from './getBooleanIndicator';
 export * from './getCodespaceState';
 export * from './getGitStatusView';


### PR DESCRIPTION
Configure the devcontainer you wish to use while starting a GitHub Codespaces instance for a component. You can provide the below annotation to a `devcontainer.json` file. The valid file path must be relative from the root of the repository as in below example.

```yaml
metadata:
  annotations:
    # other annotations
    github.com/project-slug: 'backstage/backstage'
    github.com/devcontainer-path: .devcontainer/devcontainer.json 
```